### PR TITLE
Fix BC break introduced in b6cfec0200f1670cab926fe2775ae3dfcc98f826

### DIFF
--- a/src/Command/CommandContext.php
+++ b/src/Command/CommandContext.php
@@ -126,6 +126,7 @@ class CommandContext extends BehatContext implements KernelAwareInterface
     }
 
     /**
+     * @Then /^I should see the last command output$/
      * @Then /^print last command output$/
      */
     public function iShouldSeeTheLastCommandOutput()


### PR DESCRIPTION
Thanks to @Spy-Seth who notice we can use multiple step definition
